### PR TITLE
Enable CORS and allow requests from all origins

### DIFF
--- a/hover/server.go
+++ b/hover/server.go
@@ -87,6 +87,7 @@ func notFound() routeResponse {
 }
 
 func sendReply(w http.ResponseWriter, r *http.Request, rsp *routeResponse) {
+	w.Header().Set("Access-Control-Allow-Origin", "*")
 	if rsp.body != nil {
 		if len(rsp.contentType) != 0 {
 			w.Header().Set("Content-Type", rsp.contentType)


### PR DESCRIPTION
The hoverui makes calls from a different origin. Need an additional origin header in the response to work.

Signed-off-by: Shehzad Ismail <shehzadismail89@gmail.com>