### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,18 @@
 # iomodules
-IOModule manager and plugins
+This repo contains IOModule manager (Hover Framework) and plugins
+
+# Hover Framework
+Hover framework is a userspace deamon for managing IO/Policy Modules. It exposes REST front-end for dynamically loading, configuring, linking different IO/Policy modules to make a network topology.
 
 # Requirements
-* go version 1.4 or greater
+* google go version 1.4 or greater
 * docker for some of the tests
+* BCC
 
-# Getting started
+# Installing Hover Framework
 ```bash
 # prereqs
+# make sure you have exported $GOPATH to your workspace directory.
 go get github.com/vishvananda/netns
 go get github.com/willf/bitset
 # to pull customized fork of netlink
@@ -19,12 +24,20 @@ git reset --hard drzaeus77/master
 
 go get github.com/iovisor/iomodules/hover
 go install github.com/iovisor/iomodules/hover/hoverd
+go test -v github.com/iovisor/iomodules/hover/
 
+# run the hoverd binary in standalone mode
+sudo $GOPATH/bin/hoverd
+```
+
+# Installing gbp
+```bash
+# prereqs
+# make sure you have already installed hover framework
 go get github.com/iovisor/iomodules/gbp
 sudo -E go test github.com/iovisor/iomodules/gbp
 go install github.com/iovisor/iomodules/gbp/gbp
 
-# run the binaries in standalone mode
-sudo $GOPATH/bin/hoverd
+# run the hoverd binary in standalone mode
 $GOPATH/bin/gbp -upstream $ODL_SOUTHBOUND_URL
 ```


### PR DESCRIPTION
- Separated gbp install instructions from hover framework instructions.
- Now running hover testcases to see if it's installed correctly, rather than gbp testcase.
- Hover framework requires BCC to run.