### PR TITLE
Fixes for the node deletion code path

### DIFF
--- a/hover/patch.go
+++ b/hover/patch.go
@@ -75,6 +75,9 @@ func ensureIngressFd(link netlink.Link, fd int) error {
 			if f.ClassId == fHandle {
 				return nil
 			}
+			// remove all previous filters to ensure the
+			// current one is the only one to be executed
+			netlink.FilterDel(f)
 		}
 	}
 	if err := netlink.FilterAdd(filter); err != nil {


### PR DESCRIPTION
* When deleting a A->B edge in the node, delete B->A as well

* When deleting an edge, correctly clear the forward_chain table of
  the affected iomodule

* Release ID from unreachable interfaces

* Flush old tc filters (if any) when attaching a new one

Signed-off-by: Marco Leogrande <marcol@plumgrid.com>